### PR TITLE
Fix projectiles not damaging players

### DIFF
--- a/cannon.lua
+++ b/cannon.lua
@@ -67,9 +67,9 @@ local register_spacecannon = function(def)
 				local objs = minetest.get_objects_inside_radius({x=pos.x,y=pos.y,z=pos.z}, 1)
 				local collided = false
 				for _, obj in pairs(objs) do
-					if obj:get_luaentity() ~= nil
+					if obj:is_player() or (obj:get_luaentity() ~= nil
 						and obj:get_luaentity().name ~= self.name
-						and obj:get_luaentity().name ~= "__builtin:item"
+						and obj:get_luaentity().name ~= "__builtin:item")
 					then
 						collided = true
 						obj:punch(self.object, 1.0, {
@@ -243,7 +243,7 @@ register_spacecannon({
 	is_th = true,
 	range = 1,
 	storage_require_mod = 1,
-	damage = 2,
+	damage = 8,
 	intensity = 1,
 	timeout = 8,
 	speed = 10,
@@ -259,7 +259,7 @@ register_spacecannon({
 	range = 3,
 	storage_require_mod = 3,
 	intensity = 2,
-	damage = 6,
+	damage = 10,
 	timeout = 8,
 	speed = 5,
 	penetration = 0,
@@ -274,7 +274,7 @@ register_spacecannon({
 	range = 5,
 	storage_require_mod = 5,
 	intensity = 4,
-	damage = 10,
+	damage = 18,
 	timeout = 15,
 	speed = 3,
 	penetration = 0,
@@ -300,7 +300,7 @@ register_spacecannon({
 	range = 0,
 	storage_require_mod = 1,
 	intensity = 2,
-	damage = 5,
+	damage = 10,
 	timeout = 10,
 	speed = 9,
 	penetration = 2,


### PR DESCRIPTION
This doesn't fix the incorrect logging of player damage, no idea what's causing that.

One outstanding issue is ensuring griefers can't use this to kill others with no consequences. Simply logging the cannon's owner name probably wouldn't fix this, as someone else could potentially trigger another player's cannon via digilines. Maybe log the name of the player who pulled the trigger as well?