### PR TITLE
[squashme] Pipeworks

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -8,7 +8,7 @@ read_globals = {
 	table = {fields = {"copy", "getn"}},
 
 	-- mod deps
-	"technic", "default", "digilines",
+	"default", "digilines", "pipeworks", "technic"
 
 	-- Minetest
 	"minetest",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -8,7 +8,7 @@ read_globals = {
 	table = {fields = {"copy", "getn"}},
 
 	-- mod deps
-	"default", "digilines", "pipeworks", "technic"
+	"default", "digilines", "pipeworks", "technic",
 
 	-- Minetest
 	"minetest",

--- a/cannon.lua
+++ b/cannon.lua
@@ -1,5 +1,8 @@
 -- vi: noexpandtab
 
+local has_digilines = minetest.get_modpath("digilines") and true
+local has_pipeworks = minetest.get_modpath("pipeworks") and true
+
 local cable_entry = "^technic_cable_connection_overlay.png"
 
 local groups_base = {

--- a/cannon.lua
+++ b/cannon.lua
@@ -2,6 +2,19 @@
 
 local cable_entry = "^technic_cable_connection_overlay.png"
 
+local groups_base = {
+	cracky = 3,
+	oddly_breakable_by_hand = 3,
+	technic_machine = 1,
+	technic_hv = 1
+}
+
+local groups_rail = table.copy(groups_base)
+if has_pipeworks then
+	groups_rail.tubedevice = 1
+	groups_rail.tubedevice_receiver = 1
+end
+
 local register_spacecannon = function(def)
 
 	local entity_texture = "energycube_" .. def.color .. ".png"
@@ -112,11 +125,10 @@ local register_spacecannon = function(def)
 		textures = def.textures
 	end
 
-	minetest.register_node("spacecannon:cannon_" .. def.color, {
+	local def_cannon = {
 		description = def.name .. " (" .. def.desc .. ")",
 		tiles = textures,
-
-		groups = {cracky=3,oddly_breakable_by_hand=3,technic_machine = 1, technic_hv = 1},
+		groups = def.is_th and groups_base or groups_rail,
 		drop = "spacecannon:cannon_" .. def.color,
 		sounds = default.node_sound_glass_defaults(),
 		paramtype2 = "facedir",
@@ -220,7 +232,8 @@ local register_spacecannon = function(def)
 				minetest.add_item(pos, ItemStack(meta.inventory.src[1]))
 			end
 		end
-	})
+	}
+	minetest.register_node("spacecannon:cannon_" .. def.color, def_cannon)
 
 	technic.register_machine("HV", "spacecannon:cannon_" .. def.color, technic.receiver)
 

--- a/cannon.lua
+++ b/cannon.lua
@@ -278,8 +278,6 @@ local register_spacecannon = function(def)
 		}
 	})
 
-
-
 end
 
 register_spacecannon({

--- a/cannon.lua
+++ b/cannon.lua
@@ -162,6 +162,9 @@ local register_spacecannon = function(def)
 		after_place_node = function(pos, placer)
 			local meta = minetest.get_meta(pos)
 			meta:set_string("owner", placer:get_player_name() or "")
+			if has_pipeworks then
+				pipeworks.after_place(pos)
+			end
 		end,
 
 		on_construct = function(pos)
@@ -234,8 +237,34 @@ local register_spacecannon = function(def)
 			if meta.inventory and meta.inventory.src and meta.inventory.src[1] then
 				minetest.add_item(pos, ItemStack(meta.inventory.src[1]))
 			end
+			if has_pipeworks then
+				pipeworks.after_dig(pos)
+			end
 		end
 	}
+
+	if has_pipeworks and not def.is_th then
+		def_cannon.tube = {
+			insert_object = function(pos, _, stack)
+				local meta = minetest.get_meta(pos)
+				local inv = meta:get_inventory()
+				return inv:add_item("src", stack)
+			end,
+			can_insert = function(pos, _, stack)
+				local meta = minetest.get_meta(pos)
+				local inv = meta:get_inventory()
+				stack = stack:peek_item(1)
+
+				return inv:room_for_item("src", stack)
+			end,
+			input_inventory = "src",
+			connect_sides = {
+				left = 1, back = 1, top = 1,
+				right = 1, front = 1, bottom = nil
+			}
+		}
+	end
+
 	minetest.register_node("spacecannon:cannon_" .. def.color, def_cannon)
 
 	technic.register_machine("HV", "spacecannon:cannon_" .. def.color, technic.receiver)

--- a/cannon.lua
+++ b/cannon.lua
@@ -1,6 +1,6 @@
 -- vi: noexpandtab
 
-local has_digilines = minetest.get_modpath("digilines") and true
+--local has_digilines = minetest.get_modpath("digilines") and true
 local has_pipeworks = minetest.get_modpath("pipeworks") and true
 
 local cable_entry = "^technic_cable_connection_overlay.png"

--- a/init.lua
+++ b/init.lua
@@ -12,6 +12,9 @@ spacecannon = {
 	node_resilience = {}
 }
 
+local has_digilines = minetest.get_modpath("digilines") and true
+local has_pipeworks = minetest.get_modpath("pipeworks") and true
+
 local MP = minetest.get_modpath("spacecannon")
 
 dofile(MP.."/util.lua")
@@ -21,3 +24,4 @@ dofile(MP.."/ammo.lua")
 dofile(MP.."/node_resilience.lua")
 
 print("[OK] Spacecannon")
+

--- a/init.lua
+++ b/init.lua
@@ -12,9 +12,6 @@ spacecannon = {
 	node_resilience = {}
 }
 
-local has_digilines = minetest.get_modpath("digilines") and true
-local has_pipeworks = minetest.get_modpath("pipeworks") and true
-
 local MP = minetest.get_modpath("spacecannon")
 
 dofile(MP.."/util.lua")

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = spacecannon
 description = Adds five scifi/space cannons with various properties
 depends = default, technic
-optional_depends = mesecons, digilines
+optional_depends = digilines, mesecons, pipeworks

--- a/util.lua
+++ b/util.lua
@@ -15,6 +15,7 @@ spacecannon.update_formspec = function(meta, is_th)
 			"list[current_name;src;0.375,0.5;1,1;]" ..
 			"list[current_player;main;0.375,4;8,4;]" ..
 			"listring[]" ..
+			"item_image[0.375,0.5;1,1;spacecannon:railgun_slug]" ..
 			"label[1.75,1;Ammunition]"
 
 		-- Manual "fire" button

--- a/util.lua
+++ b/util.lua
@@ -102,9 +102,9 @@ spacecannon.fire = function(pos, playername, color, speed, is_th, storage_requir
 
 	-- use ammo
 	if not is_th then
-		local src_stack = (meta:get_inventory()):get_list("src")[1]
+		local src_stack = meta:get_inventory():get_list("src")[1]
 		src_stack:take_item();
-		(meta:get_inventory()):set_stack("src", 1, src_stack)
+		meta:get_inventory():set_stack("src", 1, src_stack)
 	end
 
 	minetest.sound_play("spacecannon_shoot", {


### PR DESCRIPTION
- adds pipeworks support for the railguns, can be filled from all sides except the front
- adds icon in inventory to indicate what ammo is needed

- does not block other items than ammo to be added to inventory

closes #21