### PR TITLE
limit ammo stack size

### DIFF
--- a/ammo.lua
+++ b/ammo.lua
@@ -1,6 +1,7 @@
 minetest.register_craftitem("spacecannon:railgun_slug", {
 	description = "Railgun slug",
     inventory_image = "spacecannon_railgun_slug.png",
+    stack_max = 13,
 })
 
 minetest.register_craft({


### PR DESCRIPTION
as requested in #15
Existing bigger stacks will still work.
One can still essentially have endless fire using tubes e.g. an SCI on top of the railgun will keep stack in gun topped up to max.